### PR TITLE
Escape loaded recipes for chef pre 11.

### DIFF
--- a/recipes/ruby.rb
+++ b/recipes/ruby.rb
@@ -24,13 +24,15 @@ node.set['build_essential']['compiletime'] = true
 include_recipe "build-essential"
 include_recipe "mysql::client"
 
-if run_context.loaded_recipes.include?('mysql::percona_repo')
-  case node['platform']
-  when "ubuntu", "debian"
-    resources("apt_repository[percona]").run_action(:add)
-  when "centos", "amazon", "redhat"
-    resources("yum_key[RPM-GPG-KEY-percona]").run_action(:add)
-    resources("yum_repository[percona]").run_action(:add)
+if Chef::VERSION.to_i >= 11
+  if run_context.loaded_recipes.include?('mysql::percona_repo')
+    case node['platform']
+    when "ubuntu", "debian"
+      resources("apt_repository[percona]").run_action(:add)
+    when "centos", "amazon", "redhat"
+      resources("yum_key[RPM-GPG-KEY-percona]").run_action(:add)
+      resources("yum_repository[percona]").run_action(:add)
+    end
   end
 end
 


### PR DESCRIPTION
This blows up if you're using Chef 10 (and earlier, presumably).  This fixes that.
